### PR TITLE
Correct typo

### DIFF
--- a/src/redturtle/tiles/management/browser/static/integration.js
+++ b/src/redturtle/tiles/management/browser/static/integration.js
@@ -231,7 +231,6 @@ define(
           $.get(tilesInfosUrl, { managerId: managerId, ajax_load: true })
             .done(function(data) {
               container.html($(data).find('.tilesWrapper'));
-              container.html($(data).find('.tilesWrapper'));
 
               //throw custom event to notify when tiles are loaded
               var event = new CustomEvent('rtTilesLoaded');


### PR DESCRIPTION
`container.html($(data).find('.tilesWrapper'));` was duplicated