### PR TITLE
Fixing CI buildout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - PLONE_VERSION=5.1.x
 before_install:
   - mkdir -p $HOME/buildout-cache/{eggs,downloads}
-  - pip install -r https://raw.githubusercontent.com/plone/buildout.coredev/5.1/requirements.txt
+  - pip install -r requirements.txt
 install:
   - sed -ie "s#plone-x.x.x.cfg#plone-$PLONE_VERSION.cfg#" buildout.cfg
   - buildout -N -t 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools==38.7.0
+zc.buildout==2.11.4


### PR DESCRIPTION
In #9 checks fail due to an issue during buildout.
I replaced the requirements file from `plone/buildout.coredev` with a custom `requirements.txt` file with correct versions.

Leaving the previous version for `buildout`, I've choosen a previous version of  `setuptools` as indicated here:
https://community.plone.org/t/problem-with-buildout-plone-5-08/6260/5